### PR TITLE
IDEUtil.getConstraintString(CC) did not encode wrap gapsize

### DIFF
--- a/core/src/main/java/net/miginfocom/layout/ConstraintParser.java
+++ b/core/src/main/java/net/miginfocom/layout/ConstraintParser.java
@@ -904,7 +904,7 @@ public final class ConstraintParser
 	{
 		if (s.length() == 0 || s.equals("dialog") || s.equals("panel")) {
 			if (acceptPanel == false)
-				throw new IllegalAccessError("Insets now allowed: " + s + "\n");
+				throw new IllegalArgumentException("Insets now allowed: " + s + "\n");
 
 			boolean isPanel = s.startsWith("p");
 			UnitValue[] ins = new UnitValue[4];

--- a/ideutil/src/main/java/net/miginfocom/layout/IDEUtil.java
+++ b/ideutil/src/main/java/net/miginfocom/layout/IDEUtil.java
@@ -612,8 +612,13 @@ public class IDEUtil
 		if (noGrowAdd)
 			sb.append(asAPI ? ".grow()" : ",grow");   // Combine ".growX().growY()" into ".grow()".
 
-		if (cc.isWrap())
-			sb.append(asAPI ? ".wrap()" : ",wrap");
+		if (cc.isWrap()) {
+			BoundSize wrap = cc.getWrapGapSize();
+			if (wrap != null)
+				sb.append(asAPI ? ".wrap(\"" : ",wrap ").append(getBS(wrap)).append(asAPI ? "\")" : "");
+			else
+				sb.append(asAPI ? ".wrap()" : ",wrap");
+		}
 
 		String s = sb.toString();
 		return s.length() == 0 || s.charAt(0) != ',' ? s : s.substring(1);


### PR DESCRIPTION
The optional gap size in "wrap [gapsize]" was lost when encoding component constrains.

Also fixes exception thrown by ConstraintParser.parseInsets() from IllegalAccessError to IllegalArgumentException

(sorry, hit the wrong button and accidentally put two independent fixes into one pull request) 