### PR TITLE
enable design time "in general" if there is at least one container with design time

### DIFF
--- a/core/src/main/java/net/miginfocom/layout/LayoutUtil.java
+++ b/core/src/main/java/net/miginfocom/layout/LayoutUtil.java
@@ -142,6 +142,11 @@ public final class LayoutUtil
 		if (DT_MAP == null)
 			return HAS_BEANS && Beans.isDesignTime();
 
+		// assume design time "in general" (cw is null) if there is at least one container with design time
+		// (for storing constraints creation strings in method putCCString())
+		if (cw == null && DT_MAP != null && !DT_MAP.isEmpty() )
+			return true;
+
 		if (cw != null && DT_MAP.containsKey(cw.getComponent()) == false)
 			cw = null;
 


### PR DESCRIPTION
Had the problem with design time that
```java
LayoutUtil.setDesignTime( new SwingContainerWrapper( migPanel ), true );
```
did not store constraints creation strings in `LayoutUtil.putCCString()`, which causes problems when encoding constraints to strings later.

On the other hand
```java
LayoutUtil.setDesignTime( null, true );
```
worked, but put all MigLayout forms in JFormDesigner into design time mode. Even the forms that are not in the design view. E.g. properties or preferences dialogs. This had side effects because we're using `LayoutUtil.setDesignTimeEmptySize()`.

With this fix, `LayoutUtil.putCCString()` stores constraints strings while parsing constraints from strings and later encoding the constraints back to strings works fine.

In fact `LayoutUtil.isDesignTime()` works now as documented in its method javadoc:
> @param cw The container to set design time for. <code>null</code> is legal will return <code>true</code> if there is at least one <code>ContainerWrapper</code> (or <code>null</code>) that have design time turned on.
