### PR TITLE
fixed visual padding of non-opaque JTextField on Mac

### DIFF
--- a/examples/src/main/java/net/miginfocom/examples/VisualPaddingOSX.java
+++ b/examples/src/main/java/net/miginfocom/examples/VisualPaddingOSX.java
@@ -63,6 +63,9 @@ public class VisualPaddingOSX extends JFrame
 		JTextField ta = new JTextField("No Border");
 		ta.setBorder(new EmptyBorder(0, 0, 0, 0));
 		add(ta, cc + ", newline");
+		JTextField tfo = new JTextField("Opaque");
+		tfo.setOpaque(true);
+		add(tfo, cc);
 		add(new JTextArea("A text"), cc);
 		add(new JTextField("A text"), cc);
 		add(new JScrollPane(new JTextPane()), cc);

--- a/examples/src/main/java/net/miginfocom/examples/VisualPaddingOSX.java
+++ b/examples/src/main/java/net/miginfocom/examples/VisualPaddingOSX.java
@@ -93,6 +93,8 @@ public class VisualPaddingOSX extends JFrame
 		add(createToggle("toggle", "small", false, null), cc);
 		add(createToggle("toggle", "mini", false, null), cc);
 
+		add(createTabbedPane(), cc + ", newline, growx");
+
 		pack();
 		setLocationRelativeTo(null);
 	}
@@ -166,6 +168,14 @@ public class VisualPaddingOSX extends JFrame
 		if (key != null)
 			comboBox.putClientProperty(key, Boolean.TRUE);
 		return comboBox;
+	}
+
+	private JTabbedPane createTabbedPane()
+	{
+		JTabbedPane tabbedPane = new JTabbedPane();
+		tabbedPane.addTab("tab1", new JLabel("tab1"));
+		tabbedPane.addTab("tab2", new JLabel("tab2"));
+		return tabbedPane;
 	}
 
 	public static void main(String args[])

--- a/swing/src/main/java/net/miginfocom/swing/SwingComponentWrapper.java
+++ b/swing/src/main/java/net/miginfocom/swing/SwingComponentWrapper.java
@@ -466,7 +466,7 @@ public class SwingComponentWrapper implements ComponentWrapper
 							break;
 						case TYPE_TEXT_FIELD:
 							border = component.getBorder();
-							if (border != null && border.getClass().getSimpleName().equals("AquaTextFieldBorder")) {
+							if (!component.isOpaque() && border != null && border.getClass().getSimpleName().equals("AquaTextFieldBorder")) {
 								classID = "TextField";
 							} else {
 								classID = "";


### PR DESCRIPTION
non-opace JTextField does not have any padding on Mac

tested with
- Java 6u65, 7u72 and 8u66 on OS X 10.10
- Java 6u65 and 7u21 on OS X 10.9