### PR TITLE
Add minimum button padding

### DIFF
--- a/core/src/main/java/net/miginfocom/layout/Grid.java
+++ b/core/src/main/java/net/miginfocom/layout/Grid.java
@@ -808,7 +808,7 @@ public final class Grid
 							CompWrap cw = cell.compWraps.get(j);
 							if (tag.equals(cw.cc.getTag())) {
 								if (Character.isUpperCase(order.charAt(i)))
-									cw.adjustMinHorSizeUp(PlatformDefaults.getMinimumButtonWidth().getPixels(0, parent, cw.comp));
+								    cw.adjustMinHorSizeUp((int) UnitValue.getMinimumButtonWidthIncludingPadding(0, parent, cw.comp));
 
 								sortedList.add(cw);
 

--- a/core/src/main/java/net/miginfocom/layout/Grid.java
+++ b/core/src/main/java/net/miginfocom/layout/Grid.java
@@ -808,7 +808,7 @@ public final class Grid
 							CompWrap cw = cell.compWraps.get(j);
 							if (tag.equals(cw.cc.getTag())) {
 								if (Character.isUpperCase(order.charAt(i)))
-									cw.adjustMinHorSizeUp((int) UnitValue.getMinimumButtonWidthIncludingPadding(0, parent, cw.comp));
+									cw.adjustMinHorSizeUp((int) PlatformDefaults.getMinimumButtonWidthIncludingPadding(0, parent, cw.comp));
 
 								sortedList.add(cw);
 

--- a/core/src/main/java/net/miginfocom/layout/Grid.java
+++ b/core/src/main/java/net/miginfocom/layout/Grid.java
@@ -808,7 +808,7 @@ public final class Grid
 							CompWrap cw = cell.compWraps.get(j);
 							if (tag.equals(cw.cc.getTag())) {
 								if (Character.isUpperCase(order.charAt(i)))
-								    cw.adjustMinHorSizeUp((int) UnitValue.getMinimumButtonWidthIncludingPadding(0, parent, cw.comp));
+									cw.adjustMinHorSizeUp((int) UnitValue.getMinimumButtonWidthIncludingPadding(0, parent, cw.comp));
 
 								sortedList.add(cw);
 

--- a/core/src/main/java/net/miginfocom/layout/PlatformDefaults.java
+++ b/core/src/main/java/net/miginfocom/layout/PlatformDefaults.java
@@ -234,6 +234,7 @@ public final class PlatformDefaults
 				setGridCellGap(LPX7, LPY7);
 
 				setMinimumButtonWidth(new UnitValue(70, UnitValue.LPX, null));
+				setMinimumButtonPadding(new UnitValue(8, UnitValue.LPX, null));
 				setButtonOrder("L_HE+U+NYBXCOA_I_R");
 				setDialogInsets(LPY20, LPX20, LPY20, LPX20);
 				setPanelInsets(LPY16, LPX16, LPY16, LPX16);

--- a/core/src/main/java/net/miginfocom/layout/PlatformDefaults.java
+++ b/core/src/main/java/net/miginfocom/layout/PlatformDefaults.java
@@ -489,6 +489,16 @@ public final class PlatformDefaults
 	{
 		return BUTT_PADDING;
 	}
+    
+	public static float getMinimumButtonWidthIncludingPadding(float refValue, ContainerWrapper parent, ComponentWrapper comp)
+	{
+		final int buttonMinWidth = getMinimumButtonWidth().getPixels(refValue, parent, comp);
+		if (getMinimumButtonPadding() != null) {
+			return Math.max(comp.getMinimumWidth(comp.getWidth()) + getMinimumButtonPadding().getPixels(refValue, parent, comp) * 2, buttonMinWidth);
+		} else {
+			return buttonMinWidth;
+		}
+	}
 
 	/** Returns the unit value associated with the unit. (E.i. "related" or "indent"). Must be lower case.
 	 * @param unit The unit string.

--- a/core/src/main/java/net/miginfocom/layout/PlatformDefaults.java
+++ b/core/src/main/java/net/miginfocom/layout/PlatformDefaults.java
@@ -101,6 +101,7 @@ public final class PlatformDefaults
 	private static BoundSize DEF_VGAP = null, DEF_HGAP = null;
 	static BoundSize RELATED_X = null, RELATED_Y = null, UNRELATED_X = null, UNRELATED_Y = null;
 	private static UnitValue BUTT_WIDTH = null;
+	private static UnitValue BUTT_PADDING = null;
 
 	private static Float horScale = null, verScale = null;
 
@@ -475,6 +476,17 @@ public final class PlatformDefaults
 	public static UnitValue getMinimumButtonWidth()
 	{
 		return BUTT_WIDTH;
+	}
+	
+	public static void setMinimumButtonPadding(UnitValue padding)
+	{
+	    BUTT_PADDING = padding;
+	    MOD_COUNT++;
+	}
+	
+	public static UnitValue getMinimumButtonPadding()
+	{
+	    return BUTT_PADDING;
 	}
 
 	/** Returns the unit value associated with the unit. (E.i. "related" or "indent"). Must be lower case.

--- a/core/src/main/java/net/miginfocom/layout/PlatformDefaults.java
+++ b/core/src/main/java/net/miginfocom/layout/PlatformDefaults.java
@@ -478,16 +478,16 @@ public final class PlatformDefaults
 	{
 		return BUTT_WIDTH;
 	}
-	
+
 	public static void setMinimumButtonPadding(UnitValue padding)
 	{
-	    BUTT_PADDING = padding;
-	    MOD_COUNT++;
+		BUTT_PADDING = padding;
+		MOD_COUNT++;
 	}
-	
+
 	public static UnitValue getMinimumButtonPadding()
 	{
-	    return BUTT_PADDING;
+		return BUTT_PADDING;
 	}
 
 	/** Returns the unit value associated with the unit. (E.i. "related" or "indent"). Must be lower case.

--- a/core/src/main/java/net/miginfocom/layout/UnitValue.java
+++ b/core/src/main/java/net/miginfocom/layout/UnitValue.java
@@ -345,7 +345,7 @@ public final class UnitValue implements Serializable
 					return isHor ? comp.getMaximumWidth(comp.getHeight()) : comp.getMaximumHeight(comp.getWidth());
 
 				case BUTTON:
-					return PlatformDefaults.getMinimumButtonWidth().getPixels(refValue, parent, comp);
+				    return getMinimumButtonWidthIncludingPadding(refValue, parent, comp);
 
 				case LINK_X:
 				case LINK_Y:
@@ -402,6 +402,16 @@ public final class UnitValue implements Serializable
 
 		throw new IllegalArgumentException("Internal: Unknown Oper: " + oper);
 	}
+    
+    public static float getMinimumButtonWidthIncludingPadding(float refValue, ContainerWrapper parent, ComponentWrapper comp)
+    {
+        final int buttonMinWidth = PlatformDefaults.getMinimumButtonWidth().getPixels(refValue, parent, comp);
+        if (PlatformDefaults.getMinimumButtonPadding() != null) {
+            return Math.max(comp.getMinimumWidth(comp.getWidth()) + PlatformDefaults.getMinimumButtonPadding().getPixels(refValue, parent, comp) * 2, buttonMinWidth);
+        } else {
+            return buttonMinWidth;
+        }
+    }
 
 	private float lookup(float refValue, ContainerWrapper parent, ComponentWrapper comp)
 	{

--- a/core/src/main/java/net/miginfocom/layout/UnitValue.java
+++ b/core/src/main/java/net/miginfocom/layout/UnitValue.java
@@ -345,7 +345,7 @@ public final class UnitValue implements Serializable
 					return isHor ? comp.getMaximumWidth(comp.getHeight()) : comp.getMaximumHeight(comp.getWidth());
 
 				case BUTTON:
-				    return getMinimumButtonWidthIncludingPadding(refValue, parent, comp);
+					return getMinimumButtonWidthIncludingPadding(refValue, parent, comp);
 
 				case LINK_X:
 				case LINK_Y:
@@ -403,15 +403,15 @@ public final class UnitValue implements Serializable
 		throw new IllegalArgumentException("Internal: Unknown Oper: " + oper);
 	}
     
-    public static float getMinimumButtonWidthIncludingPadding(float refValue, ContainerWrapper parent, ComponentWrapper comp)
-    {
-        final int buttonMinWidth = PlatformDefaults.getMinimumButtonWidth().getPixels(refValue, parent, comp);
-        if (PlatformDefaults.getMinimumButtonPadding() != null) {
-            return Math.max(comp.getMinimumWidth(comp.getWidth()) + PlatformDefaults.getMinimumButtonPadding().getPixels(refValue, parent, comp) * 2, buttonMinWidth);
-        } else {
-            return buttonMinWidth;
-        }
-    }
+	public static float getMinimumButtonWidthIncludingPadding(float refValue, ContainerWrapper parent, ComponentWrapper comp)
+	{
+		final int buttonMinWidth = PlatformDefaults.getMinimumButtonWidth().getPixels(refValue, parent, comp);
+		if (PlatformDefaults.getMinimumButtonPadding() != null) {
+			return Math.max(comp.getMinimumWidth(comp.getWidth()) + PlatformDefaults.getMinimumButtonPadding().getPixels(refValue, parent, comp) * 2, buttonMinWidth);
+		} else {
+			return buttonMinWidth;
+		}
+	}
 
 	private float lookup(float refValue, ContainerWrapper parent, ComponentWrapper comp)
 	{

--- a/core/src/main/java/net/miginfocom/layout/UnitValue.java
+++ b/core/src/main/java/net/miginfocom/layout/UnitValue.java
@@ -345,7 +345,7 @@ public final class UnitValue implements Serializable
 					return isHor ? comp.getMaximumWidth(comp.getHeight()) : comp.getMaximumHeight(comp.getWidth());
 
 				case BUTTON:
-					return getMinimumButtonWidthIncludingPadding(refValue, parent, comp);
+					return PlatformDefaults.getMinimumButtonWidthIncludingPadding(refValue, parent, comp);
 
 				case LINK_X:
 				case LINK_Y:
@@ -401,16 +401,6 @@ public final class UnitValue implements Serializable
 		}
 
 		throw new IllegalArgumentException("Internal: Unknown Oper: " + oper);
-	}
-    
-	public static float getMinimumButtonWidthIncludingPadding(float refValue, ContainerWrapper parent, ComponentWrapper comp)
-	{
-		final int buttonMinWidth = PlatformDefaults.getMinimumButtonWidth().getPixels(refValue, parent, comp);
-		if (PlatformDefaults.getMinimumButtonPadding() != null) {
-			return Math.max(comp.getMinimumWidth(comp.getWidth()) + PlatformDefaults.getMinimumButtonPadding().getPixels(refValue, parent, comp) * 2, buttonMinWidth);
-		} else {
-			return buttonMinWidth;
-		}
 	}
 
 	private float lookup(float refValue, ContainerWrapper parent, ComponentWrapper comp)


### PR DESCRIPTION
Mac OS X uses a minimum button padding as well as a minimum width. This PR adds support for a minimum button padding in `PlatformDefaults` and uses it on the `BUTTON` unit value type and when processing tagged buttons.

I have included a default button padding value for Mac OS X (which is based on visual observation).