### PR TITLE
fixed NPE in PlatformDefaults.getMinimumButtonWidthIncludingPadding() on Mac

### DIFF
--- a/core/src/main/java/net/miginfocom/layout/PlatformDefaults.java
+++ b/core/src/main/java/net/miginfocom/layout/PlatformDefaults.java
@@ -493,7 +493,7 @@ public final class PlatformDefaults
 	public static float getMinimumButtonWidthIncludingPadding(float refValue, ContainerWrapper parent, ComponentWrapper comp)
 	{
 		final int buttonMinWidth = getMinimumButtonWidth().getPixels(refValue, parent, comp);
-		if (getMinimumButtonPadding() != null) {
+		if (comp != null && getMinimumButtonPadding() != null) {
 			return Math.max(comp.getMinimumWidth(comp.getWidth()) + getMinimumButtonPadding().getPixels(refValue, parent, comp) * 2, buttonMinWidth);
 		} else {
 			return buttonMinWidth;


### PR DESCRIPTION
```
Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException
	at net.miginfocom.layout.PlatformDefaults.getMinimumButtonWidthIncludingPadding(PlatformDefaults.java:497)
	at net.miginfocom.layout.UnitValue.getPixelsExact(UnitValue.java:348)
	at net.miginfocom.layout.UnitValue.getPixels(UnitValue.java:281)
	at net.miginfocom.layout.Grid.calcRowsOrColsSizes(Grid.java:1211)
	at net.miginfocom.layout.Grid.calcGridSizes(Grid.java:636)
	at net.miginfocom.layout.Grid.checkSizeCalcs(Grid.java:621)
	at net.miginfocom.layout.Grid.getWidth(Grid.java:601)
	at net.miginfocom.layout.Grid.getWidth(Grid.java:596)
	at net.miginfocom.swing.MigLayout.getSizeImpl(MigLayout.java:700)
	at net.miginfocom.swing.MigLayout.preferredLayoutSize(MigLayout.java:683)
	at java.awt.Container.preferredSize(Container.java:1796)
	at java.awt.Container.getPreferredSize(Container.java:1780)
	at javax.swing.JComponent.getPreferredSize(JComponent.java:1664)
	at net.miginfocom.swing.SwingComponentWrapper.getLayoutHashCode(SwingComponentWrapper.java:577)
	at net.miginfocom.swing.MigLayout.checkCache(MigLayout.java:450)
	at net.miginfocom.swing.MigLayout.getSizeImpl(MigLayout.java:696)
	at net.miginfocom.swing.MigLayout.preferredLayoutSize(MigLayout.java:683)
	at java.awt.Container.preferredSize(Container.java:1796)
	at java.awt.Container.getPreferredSize(Container.java:1780)
	at javax.swing.JComponent.getPreferredSize(JComponent.java:1664)
	at java.awt.BorderLayout.preferredLayoutSize(BorderLayout.java:719)
	at java.awt.Container.preferredSize(Container.java:1796)
	at java.awt.Container.getPreferredSize(Container.java:1780)
	at javax.swing.JComponent.getPreferredSize(JComponent.java:1664)
	at javax.swing.JRootPane$RootLayout.preferredLayoutSize(JRootPane.java:920)
	at java.awt.Container.preferredSize(Container.java:1796)
	at java.awt.Container.getPreferredSize(Container.java:1780)
	at javax.swing.JComponent.getPreferredSize(JComponent.java:1664)
	at java.awt.BorderLayout.preferredLayoutSize(BorderLayout.java:719)
	at java.awt.Container.preferredSize(Container.java:1796)
	at java.awt.Container.getPreferredSize(Container.java:1780)
	at java.awt.Window.pack(Window.java:809)
	...
```