### PR TITLE
make UnitValue constructor public to allow 3rd programmatic usage

### DIFF
--- a/core/src/main/java/net/miginfocom/layout/UnitValue.java
+++ b/core/src/main/java/net/miginfocom/layout/UnitValue.java
@@ -238,7 +238,7 @@ public final class UnitValue implements Serializable
 		this(value, null, unit, true, STATIC, null, null, createString);
 	}
 
-	UnitValue(float value, String unitStr, boolean isHor, int oper, String createString)
+        public UnitValue(float value, String unitStr, boolean isHor, int oper, String createString)
 	{
 		this(value, unitStr, -1, isHor, oper, null, null, createString);
 	}


### PR DESCRIPTION
In my code I use 

```kotlin
internal fun gapToBoundSize(value: Int, isHorizontal: Boolean): BoundSize {
  val unitValue = UnitValue(value.toFloat(), "", isHorizontal, UnitValue.STATIC, null)
  return BoundSize(unitValue, unitValue, null, false, null)
}
```

and want to create `UnitValue`, but it is internal.