### PR TITLE
Fix build for Java 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,16 @@
                 </plugins>
             </build>
         </profile>
+
+		<profile>
+			<id>doclint-java8-disable</id>
+			<activation>
+				<jdk>[1.8,)</jdk>
+			</activation>
+			<properties>
+				<javadoc.opts>-Xdoclint:none</javadoc.opts>
+			</properties>
+		</profile>
     </profiles>
 	<build>
 		<plugins>
@@ -86,9 +96,9 @@
 						<goals>
 							<goal>jar</goal>
 						</goals>
-                        <configuration>
-                            <additionalparam>-Xdoclint:none</additionalparam>
-                        </configuration>
+						<configuration>
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>
@@ -135,7 +145,7 @@
 				</executions>
 			</plugin>
 			 -->
-			 
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>


### PR DESCRIPTION
Hi!

Currently miglayout uses `-Xdoclint:none` option which is present only in Java 8. This means that it is impossible to build miglayout using jdk6, which in turn prevents using bleeding edge versions of miglayout via JitPack.io ([failed build log](https://jitpack.io/com/github/mikaelgrev/miglayout/f2816fc291/build.log)). 

[According to StackOverflow](http://stackoverflow.com/questions/15886209/maven-is-not-working-in-java-8-when-javadoc-tags-are-incomplete/26806103#26806103), this incantation should fix the issue and allow to build using jdk 6, 7 or 8. It seems to work locally, but I am not a maven expert :)