### PR TITLE
Use new repository for SWT

### DIFF
--- a/swt/pom.xml
+++ b/swt/pom.xml
@@ -22,8 +22,8 @@
 
     <repositories>
         <repository>
-            <id>swt-repo</id>
-            <url>https://swt-repo.googlecode.com/svn/repo/</url>
+            <id>maven-eclipse-repo</id>
+            <url>http://maven-eclipse.github.io/maven</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Hi once again! 

Currently the build fails because of

>[ERROR] Failed to execute goal on project miglayout-swt: Could not resolve dependencies for project com.miglayout:miglayout-swt:jar:5.1-SNAPSHOT: Could not find artifact org.eclipse.swt:org.eclipse.swt.gtk.linux.x86_64:jar:4.2.1 in swt-repo (https://swt-repo.googlecode.com/svn/repo/)

https://swt-repo.googlecode.com/ is dead and redirects to https://github.com/maven-eclipse/swt-repo, which redirects to https://github.com/maven-eclipse/maven-eclipse.github.io which is what used in this PR. 
