### PR TITLE
fix indices of docked components returned by IDEUtil.getGridPositions()

### DIFF
--- a/core/src/main/java/net/miginfocom/layout/Grid.java
+++ b/core/src/main/java/net/miginfocom/layout/Grid.java
@@ -1565,7 +1565,7 @@ public final class Grid
 
 	private Cell getCell(int r, int c)
 	{
-		return grid.get(Integer.valueOf((r << 16) + c));
+		return grid.get(Integer.valueOf((r << 16) + (c & 0xffff)));
 	}
 
 	private void setCell(int r, int c, Cell cell)
@@ -1579,7 +1579,7 @@ public final class Grid
 		rowIndexes.add(r);
 		colIndexes.add(c);
 
-		grid.put((r << 16) + c, cell);
+		grid.put((r << 16) + (c & 0xffff), cell);
 	}
 
 	/** Adds a docking cell. That cell is outside the normal cell indexes.
@@ -1614,7 +1614,7 @@ public final class Grid
 		rowIndexes.add(r);
 		colIndexes.add(c);
 
-		grid.put((r << 16) + c, new Cell(cw, spanx, spany, spanx > 1));
+		grid.put((r << 16) + (c & 0xffff), new Cell(cw, spanx, spany, spanx > 1));
 	}
 
 	/** A simple representation of a cell in the grid. Contains a number of component wraps, if they span more than one cell.
@@ -2436,7 +2436,7 @@ public final class Grid
 			Cell cell = e.getValue();
 			Integer xyInt = e.getKey();
 			if (xyInt != null) {
-				int x = xyInt & 0x0000ffff;
+				int x = (xyInt << 16) >> 16;
 				int y = xyInt >> 16;
 
 				for (CompWrap cw : cell.compWraps)


### PR DESCRIPTION
Indices of docked components can be negative, but the code to join/split x and y indices to/from a single integer did not consider this. As a result `IDEUtil.getGridPositions()` returns wrong indices for docked components (e.g. `-32768` or `32769`).

The join code `int xy = (r << 16) + c` returns wrong result if `c` is negative.
The split code `int x = xyInt & 0x0000ffff` never returns negative values.

Here is some code to demonstrate the problem and the fix:
```java
public class DockIndicesBug
{
	public static void main( String[] args ) {
		wrong(-32767, -32767);
		fixed(-32767, -32767);

		System.out.println();

		wrong(32767, -32767);
		fixed(32767, -32767);
	}

	private static void wrong(int r, int c) {
		System.out.println( "-- wrong" );

		int rc = (r << 16) + c;
		System.out.printf( "%6d %6d  %8x %8x --> %8x\n", r, c, r, c, rc );

		int x = rc & 0x0000ffff;
		int y = rc >> 16;
		System.out.printf( "%6d %6d  %8x %8x\n", y, x, y, x );
	}

	private static void fixed(int r, int c) {
		System.out.println( "-- fixed" );

		int rc = (r << 16) + (c & 0xffff);
		System.out.printf( "%6d %6d  %8x %8x --> %8x\n", r, c, r, c, rc );

		int x = (rc << 16) >> 16;
		int y = rc >> 16;
		System.out.printf( "%6d %6d  %8x %8x\n", y, x, y, x );
	}
}
```

Output:
```
-- wrong
-32767 -32767  ffff8001 ffff8001 --> 80008001
-32768  32769  ffff8000     8001
-- fixed
-32767 -32767  ffff8001 ffff8001 --> 80018001
-32767 -32767  ffff8001 ffff8001

-- wrong
 32767 -32767      7fff ffff8001 --> 7ffe8001
 32766  32769      7ffe     8001
-- fixed
 32767 -32767      7fff ffff8001 --> 7fff8001
 32767 -32767      7fff ffff8001
```