### PR TITLE
Baseline alignment if visual paddings enabled

### DIFF
--- a/core/src/main/java/net/miginfocom/layout/Grid.java
+++ b/core/src/main/java/net/miginfocom/layout/Grid.java
@@ -212,12 +212,12 @@ public final class Grid
 			}
 			hitEndOfRow = false;
 
-			final boolean rowNoGrid = lc.isNoGrid() || ((DimConstraint) LayoutUtil.getIndexSafe(specs, lc.isFlowX() ? cellXY[1] : cellXY[0])).isNoGrid();
+			final boolean isRowInGridMode = !lc.isNoGrid() && !((DimConstraint) LayoutUtil.getIndexSafe(specs, lc.isFlowX() ? cellXY[1] : cellXY[0])).isNoGrid();
 
 			// Move to a free y, x  if no absolute grid specified
 			int cx = rootCc.getCellX();
 			int cy = rootCc.getCellY();
-			if ((cx < 0 || cy < 0) && !rowNoGrid && rootCc.getSkip() == 0) { // 3.7.2: If skip, don't find an empty cell first.
+			if ((cx < 0 || cy < 0) && isRowInGridMode && rootCc.getSkip() == 0) { // 3.7.2: If skip, don't find an empty cell first.
 				while (!isCellFree(cellXY[1], cellXY[0], spannedRects)) {
 					if (Math.abs(increase(cellXY, 1)) >= wrap)
 						wrap(cellXY, null);
@@ -249,8 +249,8 @@ public final class Grid
 
 			// If cell is not created yet, create it and set it.
 			if (cell == null) {
-				int spanx = Math.min(rowNoGrid && lc.isFlowX() ? LayoutUtil.INF : rootCc.getSpanX(), MAX_GRID - cellXY[0]);
-				int spany = Math.min(rowNoGrid && !lc.isFlowX() ? LayoutUtil.INF : rootCc.getSpanY(), MAX_GRID - cellXY[1]);
+				int spanx = Math.min(!isRowInGridMode && lc.isFlowX() ? LayoutUtil.INF : rootCc.getSpanX(), MAX_GRID - cellXY[0]);
+				int spany = Math.min(!isRowInGridMode && !lc.isFlowX() ? LayoutUtil.INF : rootCc.getSpanY(), MAX_GRID - cellXY[1]);
 
 				cell = new Cell(spanx, spany, cellFlowX != null ? cellFlowX : lc.isFlowX());
 
@@ -263,7 +263,7 @@ public final class Grid
 
 			// Add the one, or all, components that split the grid position to the same Cell.
 			boolean wrapHandled = false;
-			int splitLeft = rowNoGrid ? LayoutUtil.INF : rootCc.getSplit() - 1;
+			int splitLeft = isRowInGridMode ? rootCc.getSplit() - 1 : LayoutUtil.INF;
 			boolean splitExit = false;
 			final boolean spanRestOfRow = (lc.isFlowX() ? rootCc.getSpanX() : rootCc.getSpanY()) == LayoutUtil.INF;
 
@@ -320,7 +320,7 @@ public final class Grid
 				}
 			}
 
-			if (!wrapHandled && !rowNoGrid) {
+			if (!wrapHandled && isRowInGridMode) {
 				int span = lc.isFlowX() ? cell.spanx : cell.spany;
 				if (Math.abs((lc.isFlowX() ? cellXY[0] : cellXY[1])) + span >= wrap) {
 					hitEndOfRow = true;

--- a/swing/src/main/java/net/miginfocom/swing/SwingComponentWrapper.java
+++ b/swing/src/main/java/net/miginfocom/swing/SwingComponentWrapper.java
@@ -75,15 +75,20 @@ public class SwingComponentWrapper implements ComponentWrapper
 	}
 
 	@Override
-	public final int getBaseline(int width, int height)
-	{
-		int baseLine = c.getBaseline(width < 0 ? c.getWidth() : width, height < 0 ? c.getHeight() : height);
-		if (baseLine != -1) {
-			int[] visPad = getVisualPadding();
-			if (visPad != null)
-				baseLine += (visPad[2] - visPad[0] + 1) / 2;
-		}
-		return baseLine;
+	public final int getBaseline(int width, int height) {
+	    int h = height;
+	    int[] visPad = getVisualPadding();
+	    if (h < 0) {
+		h = c.getHeight();
+	    }
+	    else if (visPad != null) {
+		h = height + visPad[0] + visPad[2];
+	    }
+	    int baseLine = c.getBaseline(width < 0 ? c.getWidth() : width, h);
+	    if (baseLine != -1 && visPad != null) {
+		baseLine -= visPad[0];
+	    }
+	    return baseLine;
 	}
 
 	@Override


### PR DESCRIPTION
Problem: `BasicTextFieldUI.getBaseline` returns incorrect result for height 21 (i.e. some height that less than minimal). So, in my case, baseline alignment doesn't work correctly (text in text field has 1px vertical offset compared to label text).

1. set row constraint `rowConstraints.align("baseline")`.
2. add JLabel and JTextField

```
panel.add(JLabel("text"))
panel.add(configureVisualPaddings(component))
``` 

3. `configureVisualPaddings` sets property `PlatformDefaults.VISUAL_PADDING_PROPERTY` to `intArrayOf(3, 3, 3, 3)` (it is IntelliJ LaF for macOS — 3px for focus ring).

For some reasons, method `SwingComponentWrapper.getBaseline` is called twice — one for `27` (21 visible size of text field and 3 + 3 border insets) and another one for `21`.
And BasicTextFieldUI.getBaseline() returns 16 instead of 15 for `21`.

You can say, that it is BasicTextFieldUI bug, but:

1. Why MigLayout calls `getBaseline` several times? We get baseline for component height — just correct according to visual paddings.
2. Why MigLayout calls `getBaseline` with incorrect height (we should not assume that component will be able to report correct value for incorrect input).

Probably there is more better solution, but my problem is solved now and all tests passed :)

Solution:
1. call component.getBaseline using height exactly as was reported by component (currently, we call it using corrected (according to visual paddings) height).
2. correct reported baseline. You can say, that baseline can depends on height, but — in our case it doesn't matter, because we don't change reported component height, instead, we simply change `y` (substract visual padding top).