### PR TITLE
Update SWT to 4.3; remove maven-eclipse-repo

### DIFF
--- a/swt/pom.xml
+++ b/swt/pom.xml
@@ -20,13 +20,6 @@
         </dependency>
 	</dependencies>
 
-    <repositories>
-        <repository>
-            <id>maven-eclipse-repo</id>
-            <url>https://maven-eclipse.github.io/maven</url>
-        </repository>
-    </repositories>
-
     <profiles>
         <profile>
 			<id>windows_i386</id>
@@ -43,7 +36,7 @@
                     <!--<version>3.3.0-v3346</version>-->
                     <groupId>org.eclipse.swt</groupId>
                     <artifactId>org.eclipse.swt.win32.win32.x86</artifactId>
-                    <version>4.2.1</version>
+                    <version>4.3</version>
                 </dependency>
             </dependencies>
         </profile>
@@ -60,7 +53,7 @@
                 <dependency>
                     <groupId>org.eclipse.swt</groupId>
                     <artifactId>org.eclipse.swt.win32.win32.x86_64</artifactId>
-                    <version>4.2.1</version>
+                    <version>4.3</version>
                 </dependency>
             </dependencies>
         </profile>
@@ -80,7 +73,7 @@
                     <!--<version>3.3.0-v3346</version>-->
                     <groupId>org.eclipse.swt</groupId>
                     <artifactId>org.eclipse.swt.gtk.linux.x86</artifactId>
-                    <version>4.2.1</version>
+                    <version>4.3</version>
                 </dependency>
             </dependencies>
         </profile>
@@ -100,7 +93,7 @@
                     <!--<version>3.3.0-v3346</version>-->
                     <groupId>org.eclipse.swt</groupId>
                     <artifactId>org.eclipse.swt.gtk.linux.x86_64</artifactId>
-                    <version>4.2.1</version>
+                    <version>4.3</version>
                 </dependency>
             </dependencies>
         </profile>
@@ -120,7 +113,7 @@
                     <groupId>org.eclipse.swt</groupId>
                     <!--<artifactId>org.eclipse.swt.cocoa.macosx</artifactId>-->
                     <artifactId>org.eclipse.swt.cocoa.macosx.x86_64</artifactId>
-                    <version>4.2.1</version>
+                    <version>4.3</version>
                 </dependency>
             </dependencies>
         </profile>


### PR DESCRIPTION
The miglayout-swt component [adds a Maven repository block](https://github.com/mikaelgrev/miglayout/blob/28822ff5e578a355ad541d90321dd02f21c58244/swt/pom.xml#L23-L28). This pollutes downstream builds, causing them to depend on that same repository to resolve the SWT dependency. This one in particular is problematic for me because I don't think Maven repositories hosted on GitHub can be proxied by Sonatype Nexus.

An alternative would be to update SWT from 4.2.1 to 4.3, since the 4.3 artifacts are published on Maven Central. I did not test on every platform, but I tried the build on my macOS system with the extra repository moved and version updated to 4.3, and the build succeeds for me.

Any reason this cannot be updated? If not, please merge! Thank you!