### PR TITLE
Swing: use scale factor provided by current look and feel (if supported)

### DIFF
--- a/swing/src/main/java/net/miginfocom/swing/SwingComponentWrapper.java
+++ b/swing/src/main/java/net/miginfocom/swing/SwingComponentWrapper.java
@@ -123,6 +123,14 @@ public class SwingComponentWrapper implements ComponentWrapper
 				Float s = isHor ? PlatformDefaults.getHorizontalScaleFactor() : PlatformDefaults.getVerticalScaleFactor();
 				float scaleFactor = (s != null) ? s : 1f;
 
+				// If the current look and feel is able to scale and provides
+				// an scale factor, then use it.
+				Object lafScaleFactorObj = UIManager.get( "laf.scaleFactor" );
+				if( lafScaleFactorObj instanceof Number ) {
+					float lafScaleFactor = ((Number)lafScaleFactorObj).floatValue();
+					return scaleFactor * lafScaleFactor;
+				}
+
 				// Swing in Java 9 scales automatically using the system scale factor(s) that the
 				// user can change in the system settings (Windows: Control Panel; Mac: System Preferences).
 				// Each connected screen may use its own scale factor


### PR DESCRIPTION
I'd like to propose a way to let the current Swing look and feel provide an scale factor that MigLayout uses instead its own.

Background info:
I've developed the [FlatLaf look and feel](https://github.com/JFormDesigner/FlatLaf), which supports HiDPI screens and UI scaling on Java 8 and on Linux. This works good with MigLayout in many cases, but not in all. E.g if a larger font is used in FlatLaf then the MigLayout scale factor is too small. Or on Linux, where MigLayout scale factor is always 1 even if scaling is set to 200% in Linux settings dialog.

So because the look and feel computes/decides the scale factor used for components, the layout manager should use the same scale factor.

The proposed patch uses `UIManager.get( "laf.scaleFactor" )` to get the L&F scale factor.

This has the advantage that no MigLayout API is necessary and no compile dependencies exist between MigLayout and the look and feel. This can be also used by other scaling L&Fs or other layout managers.