### PR TITLE
Limit size of child to bounds of parent when applying visualPadding

### DIFF
--- a/core/src/main/java/net/miginfocom/layout/Grid.java
+++ b/core/src/main/java/net/miginfocom/layout/Grid.java
@@ -529,7 +529,7 @@ public final class Grid
 								cw.y += bounds[1];
 
 								if (!trialRun)
-									cw.transferBounds(addVisualPadding);
+									cw.transferBounds(bounds, addVisualPadding);
 
 								if (callbackList != null) {
 									for (LayoutCallback callback : callbackList)
@@ -1904,7 +1904,7 @@ public final class Grid
 
 		/** Transfers the bounds to the component
 		 */
-		private void transferBounds(boolean addVisualPadding)
+		private void transferBounds(int[] bounds, boolean addVisualPadding)
 		{
 			if (cc.isExternal())
 				return;
@@ -1923,6 +1923,21 @@ public final class Grid
 					compY -= visualPadding[0];
 					compW += (visualPadding[1] + visualPadding[3]);
 					compH += (visualPadding[0] + visualPadding[2]);
+
+					if (compX < 0) {
+						compW -= -compX;
+						compX = 0;
+					}
+					if (compY < 0) {
+						compH -= -compY;
+						compY = 0;
+					}
+					if (compX + compW > bounds[2]) {
+						compW = bounds[2] - compX;
+					}
+					if (compY + compH > bounds[3]) {
+						compH = bounds[3] - compY;
+					}
 				}
 			}
 


### PR DESCRIPTION
If child components have e.g. the `fillx` constraint and also visualPaddings specified the child may be layed out outside the parents bounds. This results in e.g. focus rings not be painted on those side.

Here is a small example that demonstrated the problem:
````java
SwingUtilities.invokeLater(() -> {
    JFrame frame = new JFrame("Test");

    JPanel titlePanel = new JPanel(new MigLayout("fillx, insets 0", "[fill]"));

    JPanel overflowing = new JPanel();
    overflowing.setMinimumSize(new Dimension(50, 50));
    int thickness = 5;
    overflowing.setBorder(new LineBorder(Color.MAGENTA, thickness));
    overflowing.putClientProperty("visualPadding", new Insets(thickness, thickness, thickness, thickness));

    titlePanel.add(overflowing);

    JPanel panel = new JPanel(new BorderLayout());
    panel.setBorder(new CompoundBorder(
            new EmptyBorder(30, 30, 30, 30),
            new LineBorder(Color.BLACK)
    ));
    panel.add(titlePanel, BorderLayout.NORTH);
    panel.add(new JPanel(), BorderLayout.CENTER);

    frame.setContentPane(panel);

    frame.pack();
    frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
    frame.setLocationRelativeTo(null);
    frame.setVisible(true);
});
````
Without the patch the magenta border will be invisible.

I have to say that I am not entirely sure this doesn't break anything else as I am not very proficient with the library, so any feedback is highly appreciated.