### PR TITLE
chore: excute CI tests in PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - '*'
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
   build:


### PR DESCRIPTION
Previously, CI was not triggered, so it was hard to tell if the PR is workable or not.